### PR TITLE
add support for text format

### DIFF
--- a/app/controllers/comfy/cms/content_controller.rb
+++ b/app/controllers/comfy/cms/content_controller.rb
@@ -17,6 +17,7 @@ class Comfy::Cms::ContentController < Comfy::Cms::BaseController
       respond_to do |format|
         format.html { render_page }
         format.json { render :json => @cms_page }
+        format.text { render_page }
       end
     end
   end


### PR DESCRIPTION
Add support for text format.

Use case: Valendo needs a "robots.txt" manageable through the CMS for SEO (and to get staging off Google's radar :D). With text support, they could do all this with the CMS
